### PR TITLE
Fixes wezterm preventing closing tabs

### DIFF
--- a/home/dot_wezterm.lua
+++ b/home/dot_wezterm.lua
@@ -12,5 +12,19 @@ config.enable_scroll_bar = true
 
 -- Shell + Launcher Options
 config.default_domain = 'WSL:Ubuntu'
+config.skip_close_confirmation_for_processes_named = {
+    'bash',
+    'sh',
+    'zsh',
+    'fish',
+    'tmux',
+    'nu',
+    'cmd.exe',
+    'conhost.exe',
+    'pwsh.exe',
+    'powershell.exe',
+    'wsl.exe',
+    'wslhost.exe'
+  }
 
 return config


### PR DESCRIPTION
When `wezterm` with WSL, even when nothing is running (e.g. just the shell), `wezterm` will ask if you truly want to close all tabs and processes.

One way to manage this is via [`skip_close_confirmation_for_processes_named`](https://wezfurlong.org/wezterm/config/lua/config/.html`), which determines which processes are safe to close.

Thanks to the [linked snippet](https://wezfurlong.org/wezterm/config/lua/mux-events/mux-is-process-stateful.html#example) (and running, then closing `wezterm` from a powershell terminal) I was able to determine the missing processes.